### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test": "standard && tape test/*.js | tap-spec"
   },
   "dependencies": {
-    "glob": "^6.0.4",
     "find-root": "^1.0.0",
+    "glob": "^7.0.5",
     "ignore": "^3.0.9",
     "pkg-config": "^1.1.0",
     "run-parallel": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test": "standard && tape test/*.js | tap-spec"
   },
   "dependencies": {
-    "find-root": "^0.1.1",
     "glob": "^6.0.4",
+    "find-root": "^1.0.0",
     "ignore": "^3.0.9",
     "pkg-config": "^1.1.0",
     "run-parallel": "^1.1.2",


### PR DESCRIPTION
Updating `find-root` to ^1.0.0 removes a duplicate module == faster install of `standard`.

Inspired by @nolanlawson's tweet: https://twitter.com/nolanlawson/status/766275330403205122
