### PR TITLE
opts.root parameter to specify custom project root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ configKey      | 'config'      | This is the parent key in `package.json` to loo
 gitIgnoreFile  | '.gitignore'  | Name of the `.gitignore` file look for (probably best to leave it default)
 ignore         | []            | List of additional ignore patterns to use
 cwd            | process.cwd() | This is the working directory to start the deglobbing
+root           | `package.json` directory | The top-level directory which would normally contain `.gitIgnore` and/or `package.json`
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var ignorePkg = require('ignore')
 var os = require('os')
 var parallel = require('run-parallel')
 var path = require('path')
-var pkgConfig = require('pkg-config')
 var uniq = require('uniq')
 
 function deglob (files, opts, cb) {
@@ -86,7 +85,11 @@ function parseOpts (opts) {
 
   if (root) {
     if (opts.usePackageJson) {
-      var packageOpts = pkgConfig(opts.configKey, { root: false, cwd: opts.root || opts.cwd })
+      var packageOpts
+      try {
+        // load package options from package.json
+        packageOpts = require(path.join(opts.root || root, 'package.json'))[opts.configKey]
+      } catch (e) {}
       if (packageOpts && packageOpts.ignore) {
         // Use ignore patterns from package.json ("config.ignore" property)
         addIgnorePattern(packageOpts.ignore)

--- a/index.js
+++ b/index.js
@@ -78,15 +78,15 @@ function parseOpts (opts) {
     return opts
   }
 
-  // Find package.json in the project root
+  // determine root
   var root
   try {
-    root = findRoot(opts.cwd)
+    root = opts.root || findRoot(opts.cwd)
   } catch (e) {}
 
   if (root) {
     if (opts.usePackageJson) {
-      var packageOpts = pkgConfig(opts.configKey, { root: false, cwd: opts.cwd })
+      var packageOpts = pkgConfig(opts.configKey, { root: false, cwd: opts.root || opts.cwd })
       if (packageOpts && packageOpts.ignore) {
         // Use ignore patterns from package.json ("config.ignore" property)
         addIgnorePattern(packageOpts.ignore)

--- a/package.json
+++ b/package.json
@@ -30,13 +30,12 @@
     "url": "https://github.com/flet/deglob.git"
   },
   "scripts": {
-    "test": "standard && tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec"
   },
   "dependencies": {
     "find-root": "^1.0.0",
     "glob": "^7.0.5",
     "ignore": "^3.0.9",
-    "pkg-config": "^1.1.0",
     "run-parallel": "^1.1.2",
     "uniq": "^1.0.1"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -60,5 +60,21 @@ var globbies = [
     globs: ['*.txt'],
     opts: Object.assign({}, opts, {configKey: 'custom-ignore-blah'}),
     expectedFiles: ['ignored-by-package-json.txt']
+  },
+  {
+    name: '*.txt useGitIgnore: default, usePackageJson: default, root: ./playground',
+    globs: '*.txt',
+    opts: Object.assign({}, opts, {root: playground}),
+    expectedFiles: ['blah.txt']
+  },
+  {
+    name: '*.txt and *.json useGitIgnore: default, usePackageJson: default, root: <non-existant>',
+    globs: ['*.txt', '*.json'],
+    opts: Object.assign({}, opts, {root: '_'}),
+    expectedFiles: [
+      'ignored-by-git.txt',
+      'ignored-by-package-json.txt',
+      'blah.txt',
+      'package.json']
   }
 ]


### PR DESCRIPTION
PR for option 1 (explicit project root in opts) from issue #8 

The comments on [f86f526](https://github.com/j-medland/deglob/commit/f86f5261a0b8a358c2c1a06029a8371f01e800cb) explain why pkg-module is not used anymore.

If the user specified root is invalid/non-existent then the result is the same as if the useGitIgnore and usePackageJson options were false, instead of an error being thrown etc.

Cheers